### PR TITLE
The closing ?> tag MUST be omitted from files containing only PHP

### DIFF
--- a/acf-FIELD_NAME-v4.php
+++ b/acf-FIELD_NAME-v4.php
@@ -374,4 +374,4 @@ class acf_field_FIELD_NAME extends acf_field {
 // create field
 new acf_field_FIELD_NAME();
 
-?>
+

--- a/acf-FIELD_NAME-v5.php
+++ b/acf-FIELD_NAME-v5.php
@@ -542,5 +542,3 @@ class acf_field_FIELD_NAME extends acf_field {
 
 // create field
 new acf_field_FIELD_NAME();
-
-?>

--- a/acf-FIELD_NAME.php
+++ b/acf-FIELD_NAME.php
@@ -44,6 +44,3 @@ function register_fields_FIELD_NAME() {
 add_action('acf/register_fields', 'register_fields_FIELD_NAME');	
 
 
-
-	
-?>


### PR DESCRIPTION
As PSR-2
The closing `?>` tag MUST be omitted from files containing only PHP